### PR TITLE
[KV] remove feature `simulate_kv`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,3 @@ rand = "*"
 [features]
 default = ["trace_io"]
 trace_io = []
-simulate_kv = ["trace_io"]

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1,4 +1,4 @@
-use std::{hash::Hash, thread, time::Duration};
+use std::hash::Hash;
 
 use lru::LruCache;
 
@@ -8,8 +8,6 @@ where
 {
     lru: LruCache<K, ()>,
 
-    read_delay: Duration,
-
     #[cfg(feature = "trace_io")]
     pub(crate) total_wait: u64,
 }
@@ -18,11 +16,9 @@ impl<K> KVStorage<K>
 where
     K: Eq + Hash + Copy,
 {
-    pub(crate) fn new(cap: usize, read_delay: Duration) -> Self {
+    pub(crate) fn new(cap: usize) -> Self {
         Self {
             lru: LruCache::new(cap),
-
-            read_delay,
 
             #[cfg(feature = "trace_io")]
             total_wait: 0,
@@ -35,9 +31,6 @@ where
         } else {
             if cfg!(feature = "trace_io") {
                 self.total_wait += 1;
-            }
-            if cfg!(feature = "simulate_kv") {
-                thread::sleep(self.read_delay);
             }
             self.lru.put(key, ());
             false

--- a/src/line.rs
+++ b/src/line.rs
@@ -5,7 +5,6 @@ use std::{
     io::{self, Write},
     ops::{Index, IndexMut},
     sync::Mutex,
-    time::Duration,
 };
 
 use lazy_static::lazy_static;
@@ -17,8 +16,7 @@ use crate::kv::KVStorage;
 
 #[cfg(feature = "trace_io")]
 lazy_static! {
-    static ref KV: Mutex<KVStorage<(i32, u64)>> =
-        KVStorage::new(500, Duration::from_micros(2)).into();
+    static ref KV: Mutex<KVStorage<(i32, u64)>> = KVStorage::new(500).into();
 }
 
 #[cfg(feature = "trace_io")]


### PR DESCRIPTION
看起来比较鸡肋，反而会减慢跑bench的速度。我觉得计算时间的时候额外考虑一下wait的次数就可以了，故而删除